### PR TITLE
Use travis to build RPMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: bash
+sudo: required
+dist: trusty
+services: docker
+cache:
+  directories:
+    - /home/travis/.mock_cache
+
+notifications:
+  slack:
+      secure: "uF5jtMi2cSMKdcsFieYlnruHTApd5GudTCAIh/AJmuv5zO/4sU8O0VV8uTXee4MtP+pbtuBjWMnF+cG0T9Kmn41bUwj0+TYqCDiTqgTy+56jseNylFNif+DjoO7xPEefBb8D+KyGX0Zp8BxtyowCUl4KckTyCe2xQ0uu/kgySo0="
+  on_success: always # default: always
+  on_failure: always # default: always
+
+env:
+  matrix:
+    - VERSION=el73 DISTRO_VERS=7.3
+
+before_script:
+  - env | sort
+
+script:
+  # Run privileged due to mock needing fancy chroot and other device creation from RPM
+  # installs
+  - docker run --privileged=true -e DISTRO_VERS=$DISTRO_VERS --rm -it -v /home/travis/.mock_cache:/var/cache/mock -v $(pwd):/src -w /src versity/rpm-build:${VERSION} make rpm
+
+  - docker run --privileged=true -e DISTRO_VERS=$DISTRO_VERS --rm -it -v /home/travis/.mock_cache:/var/cache/mock -v $(pwd):/src -w /src versity/rpm-build:${VERSION} make kmod-rpm
+
+before_deploy:
+  - mkdir upload_rpms
+  - find . -name "*.x86_64.rpm" | xargs -n1 cp --target-directory=$(pwd)/upload_rpms
+  - ls -la upload_rpms/
+
+# vim:set et ts=2 sw=2:

--- a/pkg-linux/mock_rpmbuild.sh
+++ b/pkg-linux/mock_rpmbuild.sh
@@ -50,6 +50,11 @@ export RESULT_DIR RPM_DIR
 # mock ignores $HOME/.rpmmacros, so set here
 VENDOR="Versity Software, Inc."
 
+
+# make sure we run /usr/bin/mock
+PATH=/usr/bin:$PATH
+export PATH
+
 test_flag() {
     flag=$1
 
@@ -133,7 +138,7 @@ mock_build () {
         MOCK_OPTS="$MOCK_OPTS --no-clean --no-cleanup-after"
     fi
 
-    MOCK_OPTS="$MOCK_OPTS --uniqueext=${MOCK_UNIQUE}"
+    MOCK_OPTS="$MOCK_OPTS --uniqueext=${MOCK_UNIQUE} --old-chroot"
 
     echo "MOCK_OPTS: $MOCK_OPTS"
     echo "RPM flags: $rpm_flags"
@@ -175,6 +180,14 @@ build_centos_6x() {
     common_build
 }
 
+# Centos 7.3
+build_centos_73() {
+    MOCK_CONFIG=${MOCK_CONFIG:-"vsm2-el73-x86_64"}
+    KVERSION=${KVERSION:-"3.10.0-514.26.2.el7.x86_64"}
+    common_build
+}
+
+
 # Centos 7.x (latest)
 build_centos_7x() {
     MOCK_CONFIG=${MOCK_CONFIG:-"epel-7-x86_64"}
@@ -188,6 +201,9 @@ DISTRO_VERS=${DISTRO_VERS:-"$1"}
 case "$DISTRO_VERS" in
  "6.x")
     build_centos_6x
+    ;;
+ "7.3")
+    build_centos_73
     ;;
  "7.x")
     build_centos_7x


### PR DESCRIPTION
Now that we know and love Travis, time to feed it more RPM goodness.
This uses our recently added versity/rpm-build:el73 container to build
RPMs for EL 7.3. We need to tweak the mock run on recent Centos 7.4, as
the new chroot style doesn't work in docker.