### PR TITLE
Part2: Use modern kmod templating for kmod RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,4 +130,4 @@ kmod-tar: distclean $(RPM_DIR) mhvtl-kmod.spec
 	gzip -f -9 $(TARFILE)
 
 kmod-rpm: kmod-tar
-	env FULL_VERSION=$(FULL_VERSION) PKG_NAME=mhvtl-kmod bash pkg-linux/mock_rpmbuild.sh $(TARFILE).gz
+	env FULL_VERSION=$(FULL_VERSION) PKG_NAME=mhvtl bash pkg-linux/mock_rpmbuild.sh $(TARFILE).gz

--- a/mhvtl-kmod.spec.in
+++ b/mhvtl-kmod.spec.in
@@ -12,7 +12,7 @@ Summary: Virtual Tape Library device driver
 Name: %{kmod_name}
 %define real_version @@VERSION@@
 Version: 1.5
-Release: 5.%(echo %{kversion} | tr - _)
+Release: 6.%(echo %{kversion} | tr - _)
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://sites.google.com/site/linuxvtl2/

--- a/mhvtl-kmod.spec.in
+++ b/mhvtl-kmod.spec.in
@@ -9,7 +9,7 @@
 %define kverrel %(%{kmodtool} verrel %{?kversion} 2>/dev/null)
 
 Summary: Virtual Tape Library device driver
-Name: %{kmod_name}-kmod
+Name: %{kmod_name}
 %define real_version @@VERSION@@
 Version: 1.5
 Release: 5.%(echo %{kversion} | tr - _)
@@ -17,15 +17,14 @@ License: GPLv2
 Group: System Environment/Kernel
 URL: http://sites.google.com/site/linuxvtl2/
 
-BuildRequires: redhat-rpm-config
-BuildRequires: kernel-abi-whitelists
+BuildRequires: %kernel_module_package_buildreqs
 ExclusiveArch: i686 x86_64
 
 # Sources.
 Source0: mhvtl-%{real_version}.tar.gz
 
 # Magic hidden here.
-%{expand:%(%{kmodtool} rpmtemplate %{kmod_name} %{kversion} "" 2>/dev/null)}
+%kernel_module_package default
 
 # Disable the building of the debug package(s).
 %define debug_package %{nil}
@@ -38,21 +37,29 @@ specific build.
 
 %prep
 %setup -n %{kmod_name}-%{real_version}/kernel/
+set -- *
+mkdir source
+mv "$@" source/
+mkdir obj
 
 %build
-KSRC=%{_usrsrc}/kernels/%{kversion}
-%{__make} -C "${KSRC}" %{?_smp_mflags} modules M=$PWD
+for flavor in %flavors_to_build; do
+    rm -rf obj/$flavor
+    cp -r source obj/$flavor
+    make -C %{kernel_source $flavor} modules M=$PWD/obj/$flavor
+done
 
 %install
 export INSTALL_MOD_PATH=%{buildroot}
 export INSTALL_MOD_DIR=extra/%{kmod_name}
-KSRC=%{_usrsrc}/kernels/%{kversion}
-%{__make} -C "${KSRC}" modules_install M=$PWD
+for flavor in %flavors_to_build; do
+    make -C %{kernel_source $flavor} modules_install M=$PWD/obj/$flavor
+done
 # Set the module(s) to be executable, so that they will be stripped when packaged.
 find %{buildroot} -type f -name \*.ko -exec %{__chmod} u+x \{\} \;
 
 %clean
-%{__rm} -rf %{buildroot}
+rm -rf %{buildroot}
 
 %changelog
 * Mon Feb 1 2016 Nic Henke <nic.henke@versity.com> - 1.5.3-2

--- a/mhvtl-utils.spec.in
+++ b/mhvtl-utils.spec.in
@@ -6,7 +6,7 @@ Summary: Virtual tape library. kernel pseudo HBA driver + userspace daemons
 Name: mhvtl-utils
 %define real_version @@VERSION@@
 Version: 1.5
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: GPL
 Group: System/Kernel
 URL: http://sites.google.com/site/linuxvtl2/


### PR DESCRIPTION
Our current kmod-mhvtl RPM fails to unload, as the rpm templating was
missing kmod_version and kmod_release. This is due to half-assed
implementation using kmodtool.

To clean up our act, we'll use the more modern kernel_module_package.
See
https://wiki.linuxfoundation.org/driver-backport/sample_kmp_spec_file
for more details.
