### PR TITLE
Part3: Wait for unload ejected message in move_drive2slot

### DIFF
--- a/mhvtl-kmod.spec.in
+++ b/mhvtl-kmod.spec.in
@@ -12,7 +12,7 @@ Summary: Virtual Tape Library device driver
 Name: %{kmod_name}
 %define real_version @@VERSION@@
 Version: 1.5
-Release: 5.%(echo %{kversion} | tr - _)
+Release: 6.%(echo %{kversion} | tr - _)
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://sites.google.com/site/linuxvtl2/

--- a/mhvtl-utils.spec.in
+++ b/mhvtl-utils.spec.in
@@ -6,7 +6,7 @@ Summary: Virtual tape library. kernel pseudo HBA driver + userspace daemons
 Name: mhvtl-utils
 %define real_version @@VERSION@@
 Version: 1.5
-Release: 5%{?dist}
+Release: 6%{?dist}
 License: GPL
 Group: System/Kernel
 URL: http://sites.google.com/site/linuxvtl2/


### PR DESCRIPTION
The unload drive routine needs to wait for the ejected message from
vtltape, as that is what signifies the unload is done. This allows the
SCSI cmd completion to be entirely synchronous with the actual movement,
preventing failures during rapid load and unload cycling of a drive.
