### PR TITLE
Don't cleanup artifacts before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ notifications:
 deploy:
   - provider: script
     script: /bin/bash -x $TRAVIS_BUILD_DIR/.travis_deploy.sh
+    skip_cleanup: true
     on:
       tags: true
       all_branches: true


### PR DESCRIPTION
We don't want to nuke the jfrog binary or the RPMS before we get a
chance to upload them.