### PR TITLE
Use separate repo for EL6 artifacts

### DIFF
--- a/.travis_deploy.sh
+++ b/.travis_deploy.sh
@@ -2,4 +2,11 @@
 set -x
 
 # upload to our artifactory repo for public rpms
-./jfrog rt upload "upload_rpms/*.rpm" public-rpm
+
+REPO="public-rpm"
+
+if [[ "$VERSION" == "el6x" ]]; then
+    REPO="$REPO-el6"
+fi
+
+./jfrog rt upload "upload_rpms/*.rpm" $REPO


### PR DESCRIPTION
This simply checks the $VERSION variable, already defined in builds, and
appends '-el6'.