### PR TITLE
Build for EL7x as well as EL73

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ deploy:
 env:
   matrix:
     - VERSION=el73 DISTRO_VERS=7.3 DISTRO=.el7
+    - VERSION=el7x DISTRO_VERS=7.x DISTRO=.el7
     - VERSION=el6x DISTRO_VERS=6.x DISTRO=.el6
 
 before_script:


### PR DESCRIPTION
Kernel ABI breakages between 7.3 and 'head' have been introduced,
requiring updated packages.