### PR TITLE
Separate EL uploads

### DIFF
--- a/.travis_deploy.sh
+++ b/.travis_deploy.sh
@@ -7,6 +7,9 @@ REPO="public-rpm"
 
 if [[ "$VERSION" == "el6x" ]]; then
     REPO="$REPO-el6"
+    PATTERN="*el6*.rpm"
+else
+    PATTERN="*el7*.rpm"
 fi
 
-./jfrog rt upload "upload_rpms/*.rpm" $REPO
+./jfrog rt upload "upload_rpms/$PATTERN" $REPO


### PR DESCRIPTION
When EL6 RPMs sneak into an EL7 repo, that's bad. Since Travis builds
everything and gathers it all at once, our uploader just has to be a
little more clever.